### PR TITLE
Set isActive only for `require("lib.AppleCake")(true)`

### DIFF
--- a/AppleCake.lua
+++ b/AppleCake.lua
@@ -60,7 +60,7 @@ local emptyCounter = { }
 
 local AppleCakeRelease = {
   isDebug       = false, -- Deprecated
-  isActive      = true,  -- Replaced isDebug
+  isActive      = false, -- Replaced isDebug
   enableLevels  = AppleCakeEnableLevels,
   beginSession  = emptyFunc,
   endSession    = emptyFunc,
@@ -99,16 +99,16 @@ return function(active)
   if AppleCake then -- return appleCake if it's already been made
     return AppleCake
   end
-  
+
   AppleCake = {
-    isDebug       = false, -- Deprecated
-    isActive      = true,  -- Replaced isDebug
+    isDebug       = true, -- Deprecated
+    isActive      = true, -- Replaced isDebug
     enableLevels = AppleCakeEnableLevels,
   }
-  
+
   local threadID = threadStartIndex
   local commandTbl = { threadID }
-  
+
   if not love.timer then
     require("love.timer")
   end


### PR DESCRIPTION
If I understand it right, `AppleCake.isActive` should only be `true` if it was started with `require("lib.AppleCake")(true)`.

In my use-case I wanted to only print some debug messages when it was actually enabled, but I realised it ran regardless if AppleCake was active or not:

```lua
    if AppleCake.isActive then
      print('starting profiling session', frameNo)
    end
```

Sorry about the whitespace changes - I have my editor set up to strip trailing whitespace characters on save - feel free to reformat to your standards :)

---

BTW, I'm a big fan of what you achieved with the project - it made profiling my code easy, low-impact, and educational, plus it introduced me to the Chrome tracing tool. Thank you!